### PR TITLE
feat: add working dir .subdir/config lookup

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,11 +22,13 @@ func NewConfig(appName string) Config {
 		Finders: []Finder{
 			// 1. look for a directly configured file
 			FindDirect,
-			// 2. look for ./.<appname>.yaml
+			// 2. look for ./.<appname>.<ext>
 			FindInCwd,
-			// 3. look for ~/.<appname>.yaml
+			// 3. look for ./.<appname>/config.<ext>
+			FindInAppNameSubdir,
+			// 4. look for ~/.<appname>.<ext>
 			FindInHomeDir,
-			// 4. look for <appname>/config.yaml in xdg locations
+			// 5. look for <appname>/config.<ext> in xdg locations
 			FindInXDG,
 		},
 	}

--- a/config/finders.go
+++ b/config/finders.go
@@ -28,7 +28,7 @@ func FindDirect(cfg Config) []string {
 	return nil
 }
 
-// FindConfigYamlInCwd loads ./config.yaml -- NOTE: this is not part of the default behavior
+// FindConfigYamlInCwd looks for ./config.yaml -- NOTE: this is not part of the default behavior
 func FindConfigYamlInCwd(cfg Config) []string {
 	// check if config.yaml exists in the current directory
 	f := "./config.yaml"
@@ -40,11 +40,17 @@ func FindConfigYamlInCwd(cfg Config) []string {
 	return nil
 }
 
+// FindInCwd looks for ./.<appname>.<ext>
 func FindInCwd(cfg Config) []string {
 	return findConfigFiles(".", "."+cfg.AppName)
 }
 
-// FindInHomeDir loads from
+// FindInAppNameSubdir looks for ./.<appname>/config.<ext>
+func FindInAppNameSubdir(cfg Config) []string {
+	return findConfigFiles("."+cfg.AppName, "config")
+}
+
+// FindInHomeDir looks for ~/.<appname>.<ext>
 func FindInHomeDir(cfg Config) []string {
 	home, err := homedir.Dir()
 	if err != nil {

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -376,6 +376,26 @@ func Test_wdConfigYaml(t *testing.T) {
 	require.Equal(t, "wd-config-v", r.V)
 }
 
+func Test_wdSubdirConfigYaml(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	err = os.Chdir(path.Join(wd, "test-fixtures", "wd-subdir"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.Chdir(wd)
+	})
+
+	t.Setenv("HOME", path.Join(wd, "test-fixtures", "fake-home-dir"))
+
+	cmd, cfg, r, _ := setup(t)
+
+	err = Load(cfg, cmd, r)
+	require.NoError(t, err)
+
+	require.Equal(t, "wd-subdir-config-v", r.V)
+}
+
 func Test_homeDir(t *testing.T) {
 	disableCache := homedir.DisableCache
 	homedir.DisableCache = true

--- a/config/test-fixtures/wd-subdir/.my-app/config.yaml
+++ b/config/test-fixtures/wd-subdir/.my-app/config.yaml
@@ -1,0 +1,3 @@
+v: wd-subdir-config-v
+sub:
+  sv: wd-subdir-config-sub-v


### PR DESCRIPTION
This PR adds a case that was missed where configurations are looked up by default in `.<appname>/config.<ext>`.