### PR TITLE
fix: pointer-to-struct field handling

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,8 +3,6 @@ package fangs
 import (
 	"fmt"
 
-	"github.com/spf13/pflag"
-
 	"github.com/anchore/go-logger"
 	"github.com/anchore/go-logger/adapter/discard"
 )
@@ -16,6 +14,8 @@ type Config struct {
 	File    string        `yaml:"-" json:"-" mapstructure:"-"`
 	Finders []Finder      `yaml:"-" json:"-" mapstructure:"-"`
 }
+
+var _ FlagAdder = (*Config)(nil)
 
 func NewConfig(appName string) Config {
 	return Config{
@@ -38,6 +38,6 @@ func NewConfig(appName string) Config {
 	}
 }
 
-func (c *Config) AddFlags(flags *pflag.FlagSet) {
-	flags.StringVarP(&c.File, "config", "c", c.File, fmt.Sprintf("%s configuration file", c.AppName))
+func (c *Config) AddFlags(flags FlagSet) {
+	flags.StringVarP(&c.File, "config", "c", fmt.Sprintf("%s configuration file", c.AppName))
 }

--- a/config_test.go
+++ b/config_test.go
@@ -6,12 +6,16 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/go-logger/adapter/discard"
 )
 
 func Test_Config(t *testing.T) {
 	c := NewConfig("appName")
 	cmd := cobra.Command{}
-	c.AddFlags(cmd.Flags())
+
+	fs := NewPFlagSet(discard.New(), cmd.Flags())
+	c.AddFlags(fs)
 
 	require.NotNil(t, c.Logger)
 	require.Equal(t, "appName", c.AppName)

--- a/field_describer_test.go
+++ b/field_describer_test.go
@@ -7,12 +7,15 @@ import (
 )
 
 func Test_fieldDescriber(t *testing.T) {
-	f1 := &fdTest1{}
+	f1 := &fdTest1{
+		Ptr: &fdTest3{},
+	}
 
 	d := NewFieldDescriber(f1)
 
 	require.Equal(t, 1, f1.called)
 	require.Equal(t, 1, f1.FdTest2.called)
+	require.Equal(t, 1, f1.Ptr.called)
 
 	dd := d.(*directDescriber)
 
@@ -23,12 +26,14 @@ func Test_fieldDescriber(t *testing.T) {
 
 	require.Contains(t, values, "string description")
 	require.Contains(t, values, "int description")
+	require.Contains(t, values, "fd test 3 value description")
 }
 
 type fdTest1 struct {
 	called  int
 	String  string
 	FdTest2 fdTest2
+	Ptr     *fdTest3
 }
 
 func (f *fdTest1) DescribeFields(d FieldDescriptionSet) {
@@ -49,3 +54,15 @@ func (f *fdTest2) DescribeFields(d FieldDescriptionSet) {
 }
 
 var _ FieldDescriber = &fdTest2{}
+
+type fdTest3 struct {
+	called int
+	Value  string
+}
+
+func (f *fdTest3) DescribeFields(d FieldDescriptionSet) {
+	f.called++
+	d.Add(&f.Value, "fd test 3 value description")
+}
+
+var _ FieldDescriber = &fdTest3{}

--- a/flags.go
+++ b/flags.go
@@ -39,7 +39,16 @@ func addFlags(log logger.Logger, flags FlagSet, o any) {
 				continue
 			}
 			v := v.Field(i)
-			v = v.Addr()
+
+			if isPtr(v.Type()) {
+				if v.IsNil() {
+					newV := reflect.New(v.Type().Elem())
+					v.Set(newV)
+				}
+			} else {
+				v = v.Addr()
+			}
+
 			if !v.CanInterface() {
 				continue
 			}

--- a/load_test.go
+++ b/load_test.go
@@ -511,6 +511,9 @@ func Test_PostLoad(t *testing.T) {
 
 	r := &rootPostLoad{
 		V: "default-v",
+		Ptr: &subPostLoad{
+			Sv: "ptr-v",
+		},
 	}
 
 	cmd := &cobra.Command{}
@@ -522,12 +525,14 @@ func Test_PostLoad(t *testing.T) {
 	require.Equal(t, "direct-config-sub-v", r.Sub.Sv2)
 	require.Equal(t, "direct-config-sub-sub-v", r.Sub.Sub2.Ssv2)
 	require.Equal(t, "direct-config-sub-sub-sub-v", r.Sub.Sub2.Sub3.Sssv2)
+	require.Equal(t, "ptr-v", r.Ptr.Sv2)
 }
 
 type rootPostLoad struct {
 	V   string `json:"v" yaml:"v"`
 	V2  string
-	Sub subPostLoad `json:"sub" yaml:"sub"`
+	Ptr *subPostLoad `json:"ptr" yaml:"ptr"`
+	Sub subPostLoad  `json:"sub" yaml:"sub"`
 }
 
 func (r *rootPostLoad) PostLoad() error {


### PR DESCRIPTION
This PR corrects an issue with pointer fields not properly being called for struct tree processing, e.g.:

```go
type Config struct {
  SubStruct *SubStruct
}
```
... where `SubStruct` implements `FlagAdder`, `PostLoad`,  and/or `FieldDescriber`