### PR TITLE
Add support for multiline summaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+go.work
+go.work.sum
+
 CHANGELOG.md
 VERSION
 /test/results

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ TITLE := $(BOLD)$(PURPLE)
 SUCCESS := $(BOLD)$(GREEN)
 
 # Test variables #################################
-COVERAGE_THRESHOLD := 75  # the quality gate lower threshold for unit test total % coverage (by function statements)
+COVERAGE_THRESHOLD := 80  # the quality gate lower threshold for unit test total % coverage (by function statements)
 
 ## Build variables #################################
 VERSION := $(shell git describe --dirty --always --tags)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/adrg/xdg v0.4.0
-	github.com/anchore/go-logger v0.0.0-20230120230012-47be9bb822a2
+	github.com/anchore/go-logger v0.0.0-20230531193951-db5ae83e7dbe
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
-github.com/anchore/go-logger v0.0.0-20230120230012-47be9bb822a2 h1:gV9Mr4Tp/zvp40m1541dS9OhjlLOsWYdzP7tvqUfK/I=
-github.com/anchore/go-logger v0.0.0-20230120230012-47be9bb822a2/go.mod h1:ubLFmlsv8/DFUQrZwY5syT5/8Er3ugSr4rDFwHsE3hg=
+github.com/anchore/go-logger v0.0.0-20230531193951-db5ae83e7dbe h1:Df867YMmymdMG6z5IW8pR0/2CRpLIjYnaTXLp6j+s0k=
+github.com/anchore/go-logger v0.0.0-20230531193951-db5ae83e7dbe/go.mod h1:ubLFmlsv8/DFUQrZwY5syT5/8Er3ugSr4rDFwHsE3hg=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,8 +1,8 @@
 package fangs
 
-// PostLoad is the interface used to do any sort of processing after `config.Load` has been
+// PostLoader is the interface used to do any sort of processing after `config.Load` has been
 // called. This runs after the entire struct has been populated from the configuration files and
 // environment variables
-type PostLoad interface {
+type PostLoader interface {
 	PostLoad() error
 }

--- a/load.go
+++ b/load.go
@@ -195,7 +195,7 @@ func postLoad(v reflect.Value) error {
 		}
 
 		obj := v.Interface()
-		if p, ok := obj.(PostLoad); ok && !isPromotedMethod(obj, "PostLoad") {
+		if p, ok := obj.(PostLoader); ok && !isPromotedMethod(obj, "PostLoad") {
 			if err := p.PostLoad(); err != nil {
 				return err
 			}

--- a/load_test.go
+++ b/load_test.go
@@ -568,7 +568,7 @@ func (r *rootPostLoad) PostLoad() error {
 	return nil
 }
 
-var _ PostLoad = (*rootPostLoad)(nil)
+var _ PostLoader = (*rootPostLoad)(nil)
 
 type subPostLoad struct {
 	Sv   string `mapstructure:"sv"`
@@ -581,7 +581,7 @@ func (s *subPostLoad) PostLoad() error {
 	return nil
 }
 
-var _ PostLoad = (*subPostLoad)(nil)
+var _ PostLoader = (*subPostLoad)(nil)
 
 type subSubPostLoad struct {
 	Ssv  string `mapstructure:"ssv"`
@@ -594,7 +594,7 @@ func (s *subSubPostLoad) PostLoad() error {
 	return nil
 }
 
-var _ PostLoad = (*subSubPostLoad)(nil)
+var _ PostLoader = (*subSubPostLoad)(nil)
 
 type subSubSubPostLoad struct {
 	Sssv  string `mapstructure:"sssv"`
@@ -606,4 +606,4 @@ func (s *subSubSubPostLoad) PostLoad() error {
 	return nil
 }
 
-var _ PostLoad = (*subSubSubPostLoad)(nil)
+var _ PostLoader = (*subSubSubPostLoad)(nil)

--- a/summarize.go
+++ b/summarize.go
@@ -181,7 +181,7 @@ func stringifySection(out *bytes.Buffer, s *section, indent string) {
 	nextIndent := indent
 
 	if s.name != "" {
-		nextIndent = "  "
+		nextIndent += "  "
 
 		if s.description != "" {
 			// support multi-line descriptions

--- a/summarize.go
+++ b/summarize.go
@@ -183,6 +183,31 @@ func stringifySection(out *bytes.Buffer, s *section, indent string) {
 	if s.name != "" {
 		nextIndent = "  "
 
+		if s.description != "" {
+			// support multi-line descriptions
+			lines := strings.Split(strings.TrimSpace(s.description), "\n")
+			for idx, line := range lines {
+				out.WriteString(indent + "# " + line)
+				if idx < len(lines)-1 {
+					out.WriteString("\n")
+				}
+			}
+		}
+		if s.env != "" {
+			value := fmt.Sprintf("(env: %s)", s.env)
+			if s.description == "" {
+				// since there is no description, we need to start the comment
+				out.WriteString(indent + "# ")
+			} else {
+				// buffer between description and env hint
+				out.WriteString(" ")
+			}
+			out.WriteString(value)
+		}
+		if s.description != "" || s.env != "" {
+			out.WriteString("\n")
+		}
+
 		out.WriteString(indent)
 
 		out.WriteString(s.name)
@@ -191,19 +216,6 @@ func stringifySection(out *bytes.Buffer, s *section, indent string) {
 		if s.value.IsValid() {
 			out.WriteString(" ")
 			out.WriteString(printVal(s.value))
-		}
-
-		if s.description != "" || s.env != "" {
-			out.WriteString(" #")
-			if s.description != "" {
-				out.WriteString(" ")
-				out.WriteString(s.description)
-			}
-			if s.env != "" {
-				out.WriteString(" (env: ")
-				out.WriteString(s.env)
-				out.WriteString(")")
-			}
 		}
 
 		out.WriteString("\n")

--- a/summarize_test.go
+++ b/summarize_test.go
@@ -48,23 +48,33 @@ func Test_Summarize(t *testing.T) {
 
 	cfg := NewConfig("app")
 	s := SummarizeCommand(cfg, cmd, t0, &t0.S0, &t0.S1)
-	require.Equal(t, `Name0: 'name0 val' # name0 usage flag (env: APP_NAME0)
+	require.Equal(t, `# name0 usage flag (env: APP_NAME0)
+Name0: 'name0 val'
 
-Type0: 'type0 val' # type0 tag (env: APP_TYPE0)
+# type0 tag (env: APP_TYPE0)
+Type0: 'type0 val'
 
 s2-0:
-  Field1: 10 # field 1 usage (env: APP_S2_0_FIELD1)
+  # field 1 usage (env: APP_S2_0_FIELD1)
+  Field1: 10
   
-  Field2: true # field2 described (env: APP_S2_0_FIELD2)
+  # field2 described
+  # multiline (env: APP_S2_0_FIELD2)
+  Field2: true
   
-Name: 's1 name' # described name (env: APP_NAME)
+# described name (env: APP_NAME)
+Name: 's1 name'
 
-Type: 's1 type' # described type (env: APP_TYPE)
+# described type (env: APP_TYPE)
+Type: 's1 type'
 
 s2:
-  Field1: 11 # field 1 usage (env: APP_S2_FIELD1)
+  # field 1 usage (env: APP_S2_FIELD1)
+  Field1: 11
   
-  Field2: false # field2 described (env: APP_S2_FIELD2)
+  # field2 described
+  # multiline (env: APP_S2_FIELD2)
+  Field2: false
   
 `, s)
 }
@@ -106,7 +116,7 @@ type summarize2 struct {
 }
 
 func (s *summarize2) DescribeFields(d FieldDescriptionSet) {
-	d.Add(&s.Field2, "field2 described")
+	d.Add(&s.Field2, "field2 described\nmultiline")
 }
 
 func (s *summarize2) AddFlags(flags FlagSet) {
@@ -158,23 +168,31 @@ func Test_SummarizeValues(t *testing.T) {
 
 	s := Summarize(cfg, describers, t1)
 
-	require.Equal(t, `TopBool: false # top-bool manual description (env: APP_TOPBOOL)
+	require.Equal(t, `# top-bool manual description (env: APP_TOPBOOL)
+TopBool: false
 
-TopString: '' # top-string command description (env: APP_TOPSTRING)
+# top-string command description (env: APP_TOPSTRING)
+TopString: ''
 
-Name: '' # sub1-name manual description (env: APP_NAME)
+# sub1-name manual description (env: APP_NAME)
+Name: ''
 
-val-tsub1: 0 # val1 inline tag description (env: APP_VAL_TSUB1)
+# val1 inline tag description (env: APP_VAL_TSUB1)
+val-tsub1: 0
 
 TSub2:
-  name-tsub2: '' # sub2-name command description (env: APP_TSUB2_NAME_TSUB2)
+  # sub2-name command description (env: APP_TSUB2_NAME_TSUB2)
+  name-tsub2: ''
   
-  Val: 0 # val2 inline tag description (env: APP_TSUB2_VAL)
+  # val2 inline tag description (env: APP_TSUB2_VAL)
+  Val: 0
   
 sub3:
-  name-tsub3: '' # (env: APP_SUB3_NAME_TSUB3)
+  # (env: APP_SUB3_NAME_TSUB3)
+  name-tsub3: ''
   
-  Val: 0 # sub3-val manual description (env: APP_SUB3_VAL)
+  # sub3-val manual description (env: APP_SUB3_VAL)
+  Val: 0
   
 `, s)
 }
@@ -226,23 +244,31 @@ func Test_SummarizeValuesWithPointers(t *testing.T) {
 
 	s := SummarizeCommand(cfg, subCmd, t1)
 
-	require.Equal(t, `TopBool: false # (env: MY_APP_TOPBOOL)
+	require.Equal(t, `# (env: MY_APP_TOPBOOL)
+TopBool: false
 
-TopString: '' # top-string command description (env: MY_APP_TOPSTRING)
+# top-string command description (env: MY_APP_TOPSTRING)
+TopString: ''
 
-Name: '' # (env: MY_APP_NAME)
+# (env: MY_APP_NAME)
+Name: ''
 
-summarize1-val: 0 # summarize1-val inline tag description (env: MY_APP_SUMMARIZE1_VAL)
+# summarize1-val inline tag description (env: MY_APP_SUMMARIZE1_VAL)
+summarize1-val: 0
 
 ptr:
-  summarize2-name: 'summarize2 name' # summarize2-name command description (env: MY_APP_PTR_SUMMARIZE2_NAME)
+  # summarize2-name command description (env: MY_APP_PTR_SUMMARIZE2_NAME)
+  summarize2-name: 'summarize2 name'
   
-  Val: 2 # val 2 description (env: MY_APP_PTR_VAL)
+  # val 2 description (env: MY_APP_PTR_VAL)
+  Val: 2
   
 nil:
-  summarize2-name: '' # (env: MY_APP_NIL_SUMMARIZE2_NAME)
+  # (env: MY_APP_NIL_SUMMARIZE2_NAME)
+  summarize2-name: ''
   
-  Val: 0 # val 2 description (env: MY_APP_NIL_VAL)
+  # val 2 description (env: MY_APP_NIL_VAL)
+  Val: 0
   
 `, s)
 }

--- a/summarize_test.go
+++ b/summarize_test.go
@@ -139,12 +139,17 @@ func Test_SummarizeValues(t *testing.T) {
 		Name string `mapstructure:"name-tsub3"`
 		Val  int
 	}
+	type TSub4 struct {
+		TSub1
+		Sub2 TSub2
+	}
 	type T1 struct {
 		TopBool   bool
 		TopString string
 		TSub1     `mapstructure:",squash"`
 		TSub2     `mapstructure:""`
 		TSub3     `mapstructure:"sub3"`
+		TSub4     `mapstructure:"sub4"`
 	}
 
 	cfg := NewConfig("app")
@@ -194,6 +199,21 @@ sub3:
   # sub3-val manual description (env: APP_SUB3_VAL)
   Val: 0
   
+sub4:
+  TSub1:
+    # (env: APP_SUB4_TSUB1_NAME)
+    Name: ''
+    
+    # val1 inline tag description (env: APP_SUB4_TSUB1_VAL_TSUB1)
+    val-tsub1: 0
+    
+  Sub2:
+    # (env: APP_SUB4_SUB2_NAME_TSUB2)
+    name-tsub2: ''
+    
+    # val2 inline tag description (env: APP_SUB4_SUB2_VAL)
+    Val: 0
+    
 `, s)
 }
 

--- a/utils.go
+++ b/utils.go
@@ -6,39 +6,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-	"unicode"
 )
-
-func Indent(text, indent string) string {
-	if indent == "" {
-		return text
-	}
-	sp := strings.Split(text, "\n")
-	l := len(sp)
-	if l == 0 {
-		return ""
-	}
-	if l == 1 {
-		return indent + sp[0]
-	}
-	for i := 0; i < l; i++ {
-		// don't add indent for last whitespace-only element
-		if i == l-1 && isWhitespace(sp[i]) {
-			continue
-		}
-		sp[i] = indent + sp[i]
-	}
-	return strings.Join(sp, "\n")
-}
-
-func isWhitespace(s string) bool {
-	for _, r := range s {
-		if !unicode.IsSpace(r) {
-			return false
-		}
-	}
-	return true
-}
 
 func contains(parts []string, value string) bool {
 	for _, v := range parts {

--- a/utils_test.go
+++ b/utils_test.go
@@ -8,45 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_Indent(t *testing.T) {
-	tests := []struct {
-		name   string
-		text   string
-		indent string
-		want   string
-	}{
-		{
-			name:   "no indent",
-			text:   "single line",
-			indent: "",
-			want:   "single line",
-		},
-		{
-			name:   "single line",
-			text:   "single line",
-			indent: "  ",
-			want:   "  single line",
-		},
-		{
-			name:   "multi line",
-			text:   "multi\nline",
-			indent: "  ",
-			want:   "  multi\n  line",
-		},
-		{
-			name:   "keep trailing newline",
-			text:   "multi\nline\n\n",
-			indent: "  ",
-			want:   "  multi\n  line\n  \n",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, Indent(tt.text, tt.indent))
-		})
-	}
-}
-
 func Test_isPromotedMethod(t *testing.T) {
 	s1 := &Sub2{}
 	require.True(t, !isPromotedMethod(s1, "AddFlags"))


### PR DESCRIPTION
Today flag summaries are inline:
```
TopString: '' # top-string command description (env: MY_APP_TOPSTRING)
```

However, this breaks when the description is multiline. This PR adds support for multiline strings:
```
# top-string command ...really long line... 
# description (env: MY_APP_TOPSTRING)
TopString: '' 
```

This PR also makes the following changes:
- bumps coverage requirement from 75% to 80%
- ignore go.work* files
- rename `PostLoad` interface to `PostLoader`
- delete exported `Indent` function and replace with lib call