### PR TITLE
fix: panic due to nil logger when addFlags panics

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -58,14 +58,19 @@ func addFlags(log logger.Logger, flags FlagSet, o any) {
 	}
 }
 
-func invokeAddFlags(log logger.Logger, flags FlagSet, o any) {
-	defer func() {
-		// we need to handle embedded structs having AddFlags methods called,
-		// potentially adding flags with existing names
-		if err := recover(); err != nil {
-			log.Debugf("got error while invoking AddFlags: %#v", err)
-		}
-	}()
+func invokeAddFlags(_ logger.Logger, flags FlagSet, o any) {
+	// defer func() {
+	//	// we may need to handle embedded structs having AddFlags methods called,
+	//	// potentially adding flags with existing names. currently the isPromotedMethod
+	//  // function works, but it is fairly brittle as there is no way through standard
+	//  // go reflection to ascertain this information
+	//	if err := recover(); err != nil {
+	//		if log == nil {
+	//			panic(err)
+	//		}
+	//		log.Debugf("got error while invoking AddFlags: %v", err)
+	//	}
+	// }()
 
 	if o, ok := o.(FlagAdder); ok && !isPromotedMethod(o, "AddFlags") {
 		o.AddFlags(flags)

--- a/summarize_test.go
+++ b/summarize_test.go
@@ -238,13 +238,29 @@ func (s *Summarize2) AddFlags(flags FlagSet) {
 var _ FlagAdder = (*Summarize2)(nil)
 var _ FieldDescriber = (*Summarize2)(nil)
 
+type Summarize3 struct {
+	Name string `mapstructure:"summarize3-name"`
+	Val  int
+}
+
+func (s *Summarize3) DescribeFields(d FieldDescriptionSet) {
+	d.Add(&s.Val, "val 2 description")
+}
+
+func (s *Summarize3) AddFlags(flags FlagSet) {
+	flags.StringVarP(&s.Name, "summarize3-name", "", "summarize3-name command description")
+}
+
+var _ FlagAdder = (*Summarize3)(nil)
+var _ FieldDescriber = (*Summarize3)(nil)
+
 func Test_SummarizeValuesWithPointers(t *testing.T) {
 	type T1 struct {
 		TopBool    bool
 		TopString  string
 		Summarize1 `mapstructure:",squash"`
 		Pointer    *Summarize2 `mapstructure:"ptr"`
-		NilPointer *Summarize2 `mapstructure:"nil"`
+		NilPointer *Summarize3 `mapstructure:"nil"`
 	}
 
 	cfg := NewConfig("my-app")
@@ -284,8 +300,8 @@ ptr:
   Val: 2
   
 nil:
-  # (env: MY_APP_NIL_SUMMARIZE2_NAME)
-  summarize2-name: ''
+  # summarize3-name command description (env: MY_APP_NIL_SUMMARIZE3_NAME)
+  summarize3-name: ''
   
   # val 2 description (env: MY_APP_NIL_VAL)
   Val: 0


### PR DESCRIPTION
There was a panic handler added in the case that multiple flags are added with the same name and the pflag library panics. However, this was masking a valid panic message about the duplicates in the case the logger is nil. Modify the behavior such that panics are no longer handled here. This was only meant to be a possible workaround for having AddFlags called multiple times on embedded structs but at present isn't needed due to the `isPromotedMethod` function