### PR TITLE
fix: slice handling

### DIFF
--- a/load.go
+++ b/load.go
@@ -284,6 +284,10 @@ func isStruct(typ reflect.Type) bool {
 	return typ.Kind() == reflect.Struct
 }
 
+func isSlice(typ reflect.Type) bool {
+	return typ.Kind() == reflect.Slice
+}
+
 func isNotFoundErr(err error) bool {
 	var notFound *viper.ConfigFileNotFoundError
 	return err != nil && errors.As(err, &notFound)

--- a/load.go
+++ b/load.go
@@ -69,6 +69,8 @@ func loadConfig(cfg Config, flags flagRefs, configurations ...any) error {
 		// unmarshal fully populated viper object onto config
 		err := v.Unmarshal(configuration, func(dc *mapstructure.DecoderConfig) {
 			dc.TagName = cfg.TagName
+			// ZeroFields will use what is present in the config file instead of modifying existing defaults
+			dc.ZeroFields = true
 		})
 		if err != nil {
 			return err

--- a/load_test.go
+++ b/load_test.go
@@ -252,6 +252,35 @@ func Test_flagBoolPtrValues(t *testing.T) {
 	require.Equal(t, true, *a.Bool)
 }
 
+func Test_zeroFields(t *testing.T) {
+	type s struct {
+		List []string `mapstructure:"list"`
+	}
+	a := &s{
+		List: []string{
+			"default1",
+			"default2",
+			"default3",
+		},
+	}
+
+	cmd := &cobra.Command{}
+
+	cfg := NewConfig("app")
+	err := Load(cfg, cmd, a)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"default1", "default2", "default3"}, a.List)
+
+	t.Setenv("APP_LIST", "set1,set2")
+
+	cfg = NewConfig("app")
+	err = Load(cfg, cmd, a)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"set1", "set2"}, a.List)
+}
+
 func Test_AllFieldTypes(t *testing.T) {
 	appName := "app"
 	envName := func(name string) string {

--- a/summarize_test.go
+++ b/summarize_test.go
@@ -255,12 +255,18 @@ var _ FlagAdder = (*Summarize3)(nil)
 var _ FieldDescriber = (*Summarize3)(nil)
 
 func Test_SummarizeValuesWithPointers(t *testing.T) {
+	type Sub struct {
+		SubValue string
+		IntSlice []int
+	}
 	type T1 struct {
-		TopBool    bool
-		TopString  string
-		Summarize1 `mapstructure:",squash"`
-		Pointer    *Summarize2 `mapstructure:"ptr"`
-		NilPointer *Summarize3 `mapstructure:"nil"`
+		TopBool     bool
+		TopString   string
+		Summarize1  `mapstructure:",squash"`
+		Pointer     *Summarize2 `mapstructure:"ptr"`
+		NilPointer  *Summarize3 `mapstructure:"nil"`
+		StringSlice []string
+		SubSlice    []Sub
 	}
 
 	cfg := NewConfig("my-app")
@@ -268,6 +274,19 @@ func Test_SummarizeValuesWithPointers(t *testing.T) {
 		Pointer: &Summarize2{
 			Name: "summarize2 name",
 			Val:  2,
+		},
+		StringSlice: []string{
+			"s1",
+			"s2",
+		},
+		SubSlice: []Sub{
+			{
+				SubValue: "sv1",
+			},
+			{
+				SubValue: "sv2",
+				IntSlice: []int{3, 2, 1},
+			},
 		},
 	}
 
@@ -306,6 +325,22 @@ nil:
   # val 2 description (env: MY_APP_NIL_VAL)
   Val: 0
   
+# (env: MY_APP_STRINGSLICE)
+StringSlice: 
+  - 's1'
+  - 's2'
+
+# (env: MY_APP_SUBSLICE)
+SubSlice: 
+  - SubValue: 'sv1'
+    IntSlice: []
+
+  - SubValue: 'sv2'
+    IntSlice: 
+      - 3
+      - 2
+      - 1
+
 `, s)
 }
 


### PR DESCRIPTION
This PR corrects 2 issues:
1) Slices (including those with embedded structs/more slices) are now properly summarized in valid YAML such that a user is able to copy/paste the entire configuration to a file and edit from there
2) Slices were being modified instead of using the values from a configuration file

An example of the second issue is:
```golang
type Config struct {
  Exclude []string
}

func NewConfig() *Config {
  return &Config{
    Exclude: []string{ "some", "default", "values" },
  }
}
```
Make a config file with a different set of excludes:
```yaml
Exclude:
  - set
  - value
```
Then load this configuration file into the struct with defaults:
```golang
c := NewConfig()
fangs.Load(..., c)
```
... Viper will _modify_ entries instead of using the config file as the source of truth: `c.Exclude` contains: `"set", "value", "values"`, including a mix of defaults if the default list is longer than the config provided one.

Example (trimmed) before/after from Chronicle:

Before:
```
# output format to use: [md json] (env: CHRONICLE_OUTPUT)
output: 'md'

github:
  # (env: CHRONICLE_GITHUB_HOST)
  host: 'github.com'
  
  # (env: CHRONICLE_GITHUB_EXCLUDE_LABELS)
  exclude-labels: [duplicate question invalid wontfix wont-fix release-ignore changelog-ignore ignore]
  
  # (env: CHRONICLE_GITHUB_CONSIDER_PR_MERGE_COMMITS)
  consider-pr-merge-commits: true
  
  # (env: CHRONICLE_GITHUB_CHANGES)
  changes: [{security-fixes Security Fixes patch [security vulnerability]} {added-feature Added Features minor [enhancement feature minor]} {bug-fix Bug Fixes patch [bug fix bug-fix patch]} {breaking-feature Breaking Changes major [breaking backwards-incompatible breaking-change breaking-feature major]} {removed-feature Removed Features major [removed]} {deprecated-feature Deprecated Features minor [deprecated]} {unknown Additional Changes  []}]
 ```

After:
```
# output format to use: [md json] (env: CHRONICLE_OUTPUT)
output: 'md'

github:
  # (env: CHRONICLE_GITHUB_HOST)
  host: 'github.com'
  
  # (env: CHRONICLE_GITHUB_EXCLUDE_LABELS)
  exclude-labels: 
    - 'duplicate'
    - 'question'
    - 'invalid'
    - 'wontfix'
    - 'wont-fix'
    - 'release-ignore'
    - 'changelog-ignore'
    - 'ignore'

  # (env: CHRONICLE_GITHUB_CONSIDER_PR_MERGE_COMMITS)
  consider-pr-merge-commits: true
  
  # (env: CHRONICLE_GITHUB_CHANGES)
  changes: 
    - name: 'security-fixes'
      title: 'Security Fixes'
      semver-field: 'patch'
      labels: 
        - 'security'
        - 'vulnerability'

    - name: 'added-feature'
      title: 'Added Features'
      semver-field: 'minor'
      labels: 
        - 'enhancement'
        - 'feature'
        - 'minor'

    - name: 'bug-fix'
      title: 'Bug Fixes'
      semver-field: 'patch'
      labels: 
        - 'bug'
        - 'fix'
        - 'bug-fix'
        - 'patch'
  ...
```