### PR TITLE
feat: support APPNAME_CONFIG environment variable for config file

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package fangs
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/anchore/go-logger"
 	"github.com/anchore/go-logger/adapter/discard"
@@ -18,10 +19,15 @@ type Config struct {
 var _ FlagAdder = (*Config)(nil)
 
 func NewConfig(appName string) Config {
+	// check for environment variable <app_name>_CONFIG, if set this will be the default
+	// but will be overridden by a command-line flag
+	configFile := os.Getenv(envVar(appName, "CONFIG"))
+
 	return Config{
 		Logger:  discard.New(),
 		AppName: appName,
 		TagName: "mapstructure",
+		File:    configFile,
 		// search for configs in specific order
 		Finders: []Finder{
 			// 1. look for a directly configured file

--- a/config_test.go
+++ b/config_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/anchore/go-logger/adapter/discard"
 )
 
-func Test_Config(t *testing.T) {
+func Test_BasicConfig(t *testing.T) {
 	c := NewConfig("appName")
 	cmd := cobra.Command{}
 
@@ -26,4 +26,21 @@ func Test_Config(t *testing.T) {
 	})
 
 	require.Contains(t, flags, "config")
+}
+
+func Test_EnvVarConfig(t *testing.T) {
+	t.Setenv("APPNAME_CONFIG", "some/config.env")
+
+	c := NewConfig("appName")
+	require.Equal(t, c.File, "some/config.env")
+
+	cmd := cobra.Command{}
+
+	fs := NewPFlagSet(discard.New(), cmd.Flags())
+	c.AddFlags(fs)
+
+	// simulate the flag set
+	err := cmd.Flags().Set("config", "a/config.flag")
+	require.NoError(t, err)
+	require.Equal(t, c.File, "a/config.flag")
 }

--- a/load.go
+++ b/load.go
@@ -107,7 +107,7 @@ func configureViper(cfg Config, vpr *viper.Viper, v reflect.Value, flags flagRef
 	}
 
 	if !isStruct(t) {
-		envVar := envVar(cfg.AppName, path)
+		envVar := envVar(cfg.AppName, path...)
 		path := strings.Join(path, ".")
 
 		if flag, ok := flags[ptr]; ok {

--- a/summarize.go
+++ b/summarize.go
@@ -93,7 +93,7 @@ func summarize(cfg Config, descriptions DescriptionProvider, s *section, value r
 				name,
 				v,
 				descriptions.GetDescription(v, f),
-				envVar(cfg.AppName, path))
+				envVar(cfg.AppName, path...))
 		}
 	}
 }

--- a/utils.go
+++ b/utils.go
@@ -19,7 +19,7 @@ func contains(parts []string, value string) bool {
 
 var envVarRegex = regexp.MustCompile("[^a-zA-Z0-9_]")
 
-func envVar(appName string, parts []string) string {
+func envVar(appName string, parts ...string) string {
 	v := strings.Join(parts, "_")
 	if appName != "" {
 		v = appName + "_" + v


### PR DESCRIPTION
This PR adds support for an environment variable for the config file of the form: `<APP_NAME>_CONFIG`, which will be overridden by command-line configuration option, if specified.

Ultimately, will be the fix for: https://github.com/anchore/syft/issues/1986