### PR TITLE
Only set pointer zero value for structs 

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -38,22 +38,24 @@ func addFlags(log logger.Logger, flags FlagSet, o any) {
 			if !f.IsExported() {
 				continue
 			}
-			v := v.Field(i)
+			fv := v.Field(i)
 
-			if isPtr(v.Type()) {
-				if v.IsNil() {
-					newV := reflect.New(v.Type().Elem())
-					v.Set(newV)
+			if isPtr(fv.Type()) {
+				// check if this is a pointer to a struct, if so, we need to initialize it
+				kind := fv.Type().Elem().Kind()
+				if fv.IsNil() && kind == reflect.Struct {
+					newV := reflect.New(fv.Type().Elem())
+					fv.Set(newV)
 				}
 			} else {
-				v = v.Addr()
+				fv = fv.Addr()
 			}
 
-			if !v.CanInterface() {
+			if !fv.CanInterface() {
 				continue
 			}
 
-			addFlags(log, flags, v.Interface())
+			addFlags(log, flags, fv.Interface())
 		}
 	}
 }

--- a/flags_test.go
+++ b/flags_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/go-logger/adapter/discard"
@@ -50,6 +51,25 @@ func Test_AddFlags(t *testing.T) {
 	require.Contains(t, flagNames, "t1-flag")
 	require.Contains(t, flagNames, "sub2-flag")
 	require.Contains(t, flagNames, "sub3-flag")
+}
+
+func Test_AddFlags_StructRefs(t *testing.T) {
+	flags := pflag.NewFlagSet("set", pflag.ContinueOnError)
+
+	type ty2 struct {
+		Nested   string
+		Optional *bool // ensure this is not set
+	}
+	type ty1 struct {
+		T2 *ty2 // ensure the zero value is set
+	}
+
+	t1 := &ty1{}
+
+	AddFlags(discard.New(), flags, t1)
+
+	require.NotNil(t, t1.T2)
+	assert.Nil(t, t1.T2.Optional)
 }
 
 type Sub2 struct {


### PR DESCRIPTION
#10 fixed the behavior for initializing struct references within given configurations, however, this would also set the values of pointer values on structs (even if the pointer is to a type that is not a struct). This means if you have a `*bool` and are trying to determine if the value was provided there is no path forward since it will be set to ~`&false`. This restricts the behavior such that only pointers to struct get an instantiated instance (other types are ignored and stay nil).