### PR TITLE
fix issue where env vars couldn't be use to set fields on embedded structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ In order to use this library, a consumer will need to:
 * Define configuration structs
     * By default, use `mapstructure` struct tags (can be changed in the `Config`)
     * For embedded structs to be inline, these must use the nonstandard `,squash` option
+    * For embedded structs, the embedded type must exported if it is embedded via a pointer
 * Define Cobra commands
 * Add flags to Cobra using the `*Var*` flag variants
 * Call `config.Load` during command invocation

--- a/field_describer.go
+++ b/field_describer.go
@@ -84,7 +84,7 @@ func addFieldDescriptions(d FieldDescriptionSet, v reflect.Value) {
 
 	for i := 0; i < v.NumField(); i++ {
 		f := t.Field(i)
-		if !f.IsExported() {
+		if skipField(f) {
 			continue
 		}
 		v := v.Field(i)

--- a/flags.go
+++ b/flags.go
@@ -35,7 +35,7 @@ func addFlags(log logger.Logger, flags FlagSet, o any) {
 	if isStruct(t) {
 		for i := 0; i < t.NumField(); i++ {
 			f := t.Field(i)
-			if !f.IsExported() {
+			if skipField(f) {
 				continue
 			}
 			v := v.Field(i)

--- a/load.go
+++ b/load.go
@@ -89,6 +89,8 @@ func loadConfig(cfg Config, flags flagRefs, configurations ...any) error {
 // configureViper loads the default configuration values into the viper instance,
 // before the config values are read and parsed. the value _must_ be a pointer but
 // may be a pointer to a pointer
+//
+//nolint:gocognit
 func configureViper(cfg Config, vpr *viper.Viper, v reflect.Value, flags flagRefs, path []string) {
 	t := v.Type()
 	if !isPtr(t) {

--- a/load_test.go
+++ b/load_test.go
@@ -621,7 +621,8 @@ func Test_EmbeddedStructPointerInConfigMember(t *testing.T) {
 
 	// Note that, unlike Test_EmbeddedStructInConfigMember above,
 	// in this test, ModuleConfig is exported. This is a language
-	// limitation. See
+	// limitation. See https://go-review.googlesource.com/c/go/+/53643
+	// and https://github.com/golang/go/issues/21357
 	type specialModuleConfig struct {
 		*ModuleConfig     `yaml:",inline" mapstructure:",squash"`
 		SpecialModuleBool bool `yaml:"special-module-bool" mapstructure:"special-module-bool"`
@@ -645,6 +646,37 @@ func Test_EmbeddedStructPointerInConfigMember(t *testing.T) {
 	require.True(t, cfgPtr.Module1.ModuleBool)
 	require.True(t, cfgPtr.Module2.ModuleBool)
 	require.True(t, cfgPtr.Module2.SpecialModuleBool)
+}
+
+func Test_EmbeddedPrivateStructPointerInConfigMemberDoesNotPanic(t *testing.T) {
+	// Embedded an unexported struct via a pointer cannot be set by reflection,
+	// see comment in test case above.
+	// Assert that in this case fangs does not panic, and bubbles up the error from mapstructure.
+	type moduleConfig struct {
+		ModuleBool bool `yaml:"module-bool" mapstructure:"module-bool"`
+	}
+
+	type specialModuleConfig struct {
+		*moduleConfig     `yaml:",inline" mapstructure:",squash"`
+		SpecialModuleBool bool `yaml:"special-module-bool" mapstructure:"special-module-bool"`
+	}
+
+	type TopLevelConfig struct {
+		Module1 moduleConfig        `yaml:"module-1" mapstructure:"module-1"`
+		Module2 specialModuleConfig `yaml:"module-2" mapstructure:"module-2"`
+	}
+
+	cfgPtr := &TopLevelConfig{}
+
+	cfg := NewConfig("my-app")
+	t.Setenv("MY_APP_MODULE_1_MODULE_BOOL", "true")
+	t.Setenv("MY_APP_MODULE_2_MODULE_BOOL", "true")
+	t.Setenv("MY_APP_MODULE_2_SPECIAL_MODULE_BOOL", "true")
+
+	cmd := &cobra.Command{}
+	err := Load(cfg, cmd, cfgPtr)
+	// https://github.com/mitchellh/mapstructure/blob/bf980b35cac4dfd34e05254ee5aba086504c3f96/mapstructure.go#L1338
+	assert.ErrorContains(t, err, "unsupported type for squash")
 }
 
 type rootPostLoad struct {

--- a/load_test.go
+++ b/load_test.go
@@ -584,6 +584,36 @@ func Test_PostLoad(t *testing.T) {
 	require.Equal(t, "ptr-v", r.Ptr.Sv2)
 }
 
+func Test_EmbeddedStructInConfigMember(t *testing.T) {
+	type moduleConfig struct {
+		ModuleBool bool `yaml:"module-bool" mapstructure:"module-bool"`
+	}
+
+	type specialModuleConfig struct {
+		moduleConfig      `yaml:",inline" mapstructure:",squash"`
+		SpecialModuleBool bool `yaml:"special-module-bool" mapstructure:"special-module-bool"`
+	}
+
+	type TopLevelConfig struct {
+		Module1 moduleConfig        `yaml:"module-1" mapstructure:"module-1"`
+		Module2 specialModuleConfig `yaml:"module-2" mapstructure:"module-2"`
+	}
+
+	cfgPtr := &TopLevelConfig{}
+
+	cfg := NewConfig("my-app")
+	t.Setenv("MY_APP_MODULE_1_MODULE_BOOL", "true")
+	t.Setenv("MY_APP_MODULE_2_MODULE_BOOL", "true")
+	t.Setenv("MY_APP_MODULE_2_SPECIAL_MODULE_BOOL", "true")
+
+	cmd := &cobra.Command{}
+	err := Load(cfg, cmd, cfgPtr)
+	require.NoError(t, err)
+	require.True(t, cfgPtr.Module1.ModuleBool)
+	require.True(t, cfgPtr.Module2.ModuleBool)
+	require.True(t, cfgPtr.Module2.SpecialModuleBool)
+}
+
 type rootPostLoad struct {
 	V    string `mapstructure:"v"`
 	V2   string

--- a/summarize.go
+++ b/summarize.go
@@ -50,7 +50,7 @@ func summarize(cfg Config, descriptions DescriptionProvider, s *section, value r
 
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
-		if !f.IsExported() {
+		if skipField(f) {
 			continue
 		}
 
@@ -134,7 +134,7 @@ func printVal(cfg Config, value reflect.Value, indent string) string {
 	case isStruct(t):
 		for i := 0; i < t.NumField(); i++ {
 			f := t.Field(i)
-			if !f.IsExported() {
+			if skipField(f) {
 				continue
 			}
 


### PR DESCRIPTION
Introduce helper method to decide if a field should be skipped.