### PR TITLE
chore: bump golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,7 +12,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - depguard
     - dogsled
     - dupl
     - errcheck

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ LINT_CMD := $(TEMP_DIR)/golangci-lint run --tests=false
 GOIMPORTS_CMD := $(TEMP_DIR)/gosimports -local github.com/anchore
 
 # Tool versions #################################
-GOLANGCILINT_VERSION := v1.52.1
+GOLANGCILINT_VERSION := v1.55.1
 GOSIMPORTS_VERSION := v0.3.8
 BOUNCER_VERSION := v0.4.0
 


### PR DESCRIPTION
Disable depgaurd, since it is disabled in grype and fails on main.

This bumps golangci-lint version to match the version currently used in grype.

Bumping because the old version of golangci-lint won't run locally for me. 