### PR TITLE
fix: correct handling of embedded structs in config

### DIFF
--- a/field_describer.go
+++ b/field_describer.go
@@ -84,7 +84,7 @@ func addFieldDescriptions(d FieldDescriptionSet, v reflect.Value) {
 
 	for i := 0; i < v.NumField(); i++ {
 		f := t.Field(i)
-		if skipField(f) {
+		if !includeField(f) {
 			continue
 		}
 		v := v.Field(i)

--- a/field_describer.go
+++ b/field_describer.go
@@ -69,7 +69,7 @@ func (d *directDescriber) GetDescription(v reflect.Value, _ reflect.StructField)
 
 func addFieldDescriptions(d FieldDescriptionSet, v reflect.Value) {
 	t := v.Type()
-	for isPtr(t) {
+	for isPtr(t) && v.CanInterface() {
 		o := v.Interface()
 		if p, ok := o.(FieldDescriber); ok && !isPromotedMethod(o, "DescribeFields") {
 			p.DescribeFields(d)

--- a/field_describer_test.go
+++ b/field_describer_test.go
@@ -29,6 +29,63 @@ func Test_fieldDescriber(t *testing.T) {
 	require.Contains(t, values, "fd test 3 value description")
 }
 
+func Test_FieldDescriberDoesNotPanicOnEmbeddedUnexportedStruct(t *testing.T) {
+	type moduleConfig struct {
+		ModuleBool bool `yaml:"module-bool" mapstructure:"module-bool"`
+	}
+
+	type specialModuleConfig struct {
+		moduleConfig      `yaml:",inline" mapstructure:",squash"`
+		SpecialModuleBool bool `yaml:"special-module-bool" mapstructure:"special-module-bool"`
+	}
+
+	type TopLevelConfig struct {
+		Module1 moduleConfig        `yaml:"module-1" mapstructure:"module-1"`
+		Module2 specialModuleConfig `yaml:"module-2" mapstructure:"module-2"`
+	}
+
+	cfgPtr := &TopLevelConfig{}
+	_ = NewFieldDescriber(cfgPtr)
+}
+
+func Test_FieldDescriberDoesNotPanicOnEmbeddedExportedStructPointer(t *testing.T) {
+	type ModuleConfig struct {
+		ModuleBool bool `yaml:"module-bool" mapstructure:"module-bool"`
+	}
+
+	type specialModuleConfig struct {
+		*ModuleConfig     `yaml:",inline" mapstructure:",squash"`
+		SpecialModuleBool bool `yaml:"special-module-bool" mapstructure:"special-module-bool"`
+	}
+
+	type TopLevelConfig struct {
+		Module1 ModuleConfig        `yaml:"module-1" mapstructure:"module-1"`
+		Module2 specialModuleConfig `yaml:"module-2" mapstructure:"module-2"`
+	}
+
+	cfgPtr := &TopLevelConfig{}
+	_ = NewFieldDescriber(cfgPtr)
+}
+
+func Test_FieldDescriberDoesNotPanicOnEmbeddedUnexportedStructPointer(t *testing.T) {
+	type moduleConfig struct {
+		ModuleBool bool `yaml:"module-bool" mapstructure:"module-bool"`
+	}
+
+	type specialModuleConfig struct {
+		*moduleConfig     `yaml:",inline" mapstructure:",squash"`
+		SpecialModuleBool bool `yaml:"special-module-bool" mapstructure:"special-module-bool"`
+	}
+
+	type TopLevelConfig struct {
+		Module1 moduleConfig        `yaml:"module-1" mapstructure:"module-1"`
+		Module2 specialModuleConfig `yaml:"module-2" mapstructure:"module-2"`
+	}
+
+	cfgPtr := &TopLevelConfig{}
+	_ = NewFieldDescriber(cfgPtr)
+}
+
 type fdTest1 struct {
 	called  int
 	String  string

--- a/flags.go
+++ b/flags.go
@@ -45,7 +45,9 @@ func addFlags(log logger.Logger, flags FlagSet, o any) {
 				kind := v.Type().Elem().Kind()
 				if v.IsNil() && kind == reflect.Struct {
 					newV := reflect.New(v.Type().Elem())
-					v.Set(newV)
+					if v.CanSet() {
+						v.Set(newV)
+					}
 				}
 			} else {
 				v = v.Addr()

--- a/flags.go
+++ b/flags.go
@@ -35,7 +35,7 @@ func addFlags(log logger.Logger, flags FlagSet, o any) {
 	if isStruct(t) {
 		for i := 0; i < t.NumField(); i++ {
 			f := t.Field(i)
-			if skipField(f) {
+			if !includeField(f) {
 				continue
 			}
 			v := v.Field(i)

--- a/load_test.go
+++ b/load_test.go
@@ -584,97 +584,99 @@ func Test_PostLoad(t *testing.T) {
 	require.Equal(t, "ptr-v", r.Ptr.Sv2)
 }
 
-func Test_EmbeddedStructInConfigMember(t *testing.T) {
-	type moduleConfig struct {
-		ModuleBool bool `yaml:"module-bool" mapstructure:"module-bool"`
-	}
-
-	type specialModuleConfig struct {
-		moduleConfig      `yaml:",inline" mapstructure:",squash"`
-		SpecialModuleBool bool `yaml:"special-module-bool" mapstructure:"special-module-bool"`
-	}
-
-	type TopLevelConfig struct {
-		Module1 moduleConfig        `yaml:"module-1" mapstructure:"module-1"`
-		Module2 specialModuleConfig `yaml:"module-2" mapstructure:"module-2"`
-	}
-
-	cfgPtr := &TopLevelConfig{}
-
-	cfg := NewConfig("my-app")
-	t.Setenv("MY_APP_MODULE_1_MODULE_BOOL", "true")
-	t.Setenv("MY_APP_MODULE_2_MODULE_BOOL", "true")
-	t.Setenv("MY_APP_MODULE_2_SPECIAL_MODULE_BOOL", "true")
-
-	cmd := &cobra.Command{}
-	err := Load(cfg, cmd, cfgPtr)
-	require.NoError(t, err)
-	require.True(t, cfgPtr.Module1.ModuleBool)
-	require.True(t, cfgPtr.Module2.ModuleBool)
-	require.True(t, cfgPtr.Module2.SpecialModuleBool)
+type Public struct {
+	Value bool `json:"value" yaml:"value" mapstructure:"value"`
 }
 
-func Test_EmbeddedStructPointerInConfigMember(t *testing.T) {
-	type ModuleConfig struct {
-		ModuleBool bool `yaml:"module-bool" mapstructure:"module-bool"`
-	}
+type private struct {
+	Value bool `json:"value" yaml:"value" mapstructure:"value"`
+}
 
-	// Note that, unlike Test_EmbeddedStructInConfigMember above,
-	// in this test, ModuleConfig is exported. This is a language
-	// limitation. See https://go-review.googlesource.com/c/go/+/53643
+func Test_EmbeddedPublicStruct(t *testing.T) {
+	val := &struct {
+		Public      `yaml:",inline" mapstructure:",squash"`
+		PublicField struct {
+			Public `yaml:",inline" mapstructure:",squash"`
+		} `yaml:"field" mapstructure:"field"`
+	}{}
+
+	cfg := NewConfig("app")
+	t.Setenv("APP_VALUE", "true")
+	t.Setenv("APP_FIELD_VALUE", "true")
+
+	cmd := &cobra.Command{}
+	err := Load(cfg, cmd, val)
+
+	require.NoError(t, err)
+	require.NotNil(t, val.Public)
+	require.True(t, val.Public.Value)
+	require.NotNil(t, val.PublicField.Public)
+	require.True(t, val.PublicField.Public.Value)
+}
+
+func Test_EmbeddedPublicStructPointer(t *testing.T) {
+	val := &struct {
+		*Public     `yaml:",inline" mapstructure:",squash"`
+		PublicField struct {
+			*Public `yaml:",inline" mapstructure:",squash"`
+		} `yaml:"field" mapstructure:"field"`
+	}{}
+
+	cfg := NewConfig("app")
+	t.Setenv("APP_VALUE", "true")
+	t.Setenv("APP_FIELD_VALUE", "true")
+
+	cmd := &cobra.Command{}
+	err := Load(cfg, cmd, val)
+
+	require.NoError(t, err)
+	require.NotNil(t, val.Public)
+	require.True(t, val.Public.Value)
+	require.NotNil(t, val.PublicField.Public)
+	require.True(t, val.PublicField.Value)
+}
+
+func Test_EmbeddedPrivateStruct(t *testing.T) {
+	val := &struct {
+		private     `yaml:",inline" mapstructure:",squash"`
+		PublicField struct {
+			private `yaml:",inline" mapstructure:",squash"`
+		} `yaml:"field" mapstructure:"field"`
+	}{}
+
+	cfg := NewConfig("app")
+	t.Setenv("APP_VALUE", "true")
+	t.Setenv("APP_FIELD_VALUE", "true")
+
+	cmd := &cobra.Command{}
+	err := Load(cfg, cmd, val)
+
+	require.NoError(t, err)
+	require.NotNil(t, val.private)
+	require.True(t, val.private.Value)
+	require.NotNil(t, val.PublicField.private)
+	require.True(t, val.PublicField.private.Value)
+}
+
+func Test_EmbeddedPrivateStructPointer(t *testing.T) {
+	// Note that, unlike Test_EmbeddedPublicStructPointer above,
+	// in this test, *private is not exported and cannot be set or addressed.
+	// This is a language limitation. See https://go-review.googlesource.com/c/go/+/53643
 	// and https://github.com/golang/go/issues/21357
-	type specialModuleConfig struct {
-		*ModuleConfig     `yaml:",inline" mapstructure:",squash"`
-		SpecialModuleBool bool `yaml:"special-module-bool" mapstructure:"special-module-bool"`
-	}
+	val := &struct {
+		*private    `yaml:",inline" mapstructure:",squash"`
+		PublicField struct {
+			*private `yaml:",inline" mapstructure:",squash"`
+		} `yaml:"field" mapstructure:"field"`
+	}{}
 
-	type TopLevelConfig struct {
-		Module1 ModuleConfig        `yaml:"module-1" mapstructure:"module-1"`
-		Module2 specialModuleConfig `yaml:"module-2" mapstructure:"module-2"`
-	}
-
-	cfgPtr := &TopLevelConfig{}
-
-	cfg := NewConfig("my-app")
-	t.Setenv("MY_APP_MODULE_1_MODULE_BOOL", "true")
-	t.Setenv("MY_APP_MODULE_2_MODULE_BOOL", "true")
-	t.Setenv("MY_APP_MODULE_2_SPECIAL_MODULE_BOOL", "true")
+	cfg := NewConfig("app")
+	t.Setenv("APP_VALUE", "true")
+	t.Setenv("APP_FIELD_VALUE", "true")
 
 	cmd := &cobra.Command{}
-	err := Load(cfg, cmd, cfgPtr)
-	require.NoError(t, err)
-	require.True(t, cfgPtr.Module1.ModuleBool)
-	require.True(t, cfgPtr.Module2.ModuleBool)
-	require.True(t, cfgPtr.Module2.SpecialModuleBool)
-}
+	err := Load(cfg, cmd, val)
 
-func Test_EmbeddedPrivateStructPointerInConfigMemberDoesNotPanic(t *testing.T) {
-	// Embedded an unexported struct via a pointer cannot be set by reflection,
-	// see comment in test case above.
-	// Assert that in this case fangs does not panic, and bubbles up the error from mapstructure.
-	type moduleConfig struct {
-		ModuleBool bool `yaml:"module-bool" mapstructure:"module-bool"`
-	}
-
-	type specialModuleConfig struct {
-		*moduleConfig     `yaml:",inline" mapstructure:",squash"`
-		SpecialModuleBool bool `yaml:"special-module-bool" mapstructure:"special-module-bool"`
-	}
-
-	type TopLevelConfig struct {
-		Module1 moduleConfig        `yaml:"module-1" mapstructure:"module-1"`
-		Module2 specialModuleConfig `yaml:"module-2" mapstructure:"module-2"`
-	}
-
-	cfgPtr := &TopLevelConfig{}
-
-	cfg := NewConfig("my-app")
-	t.Setenv("MY_APP_MODULE_1_MODULE_BOOL", "true")
-	t.Setenv("MY_APP_MODULE_2_MODULE_BOOL", "true")
-	t.Setenv("MY_APP_MODULE_2_SPECIAL_MODULE_BOOL", "true")
-
-	cmd := &cobra.Command{}
-	err := Load(cfg, cmd, cfgPtr)
 	// https://github.com/mitchellh/mapstructure/blob/bf980b35cac4dfd34e05254ee5aba086504c3f96/mapstructure.go#L1338
 	assert.ErrorContains(t, err, "unsupported type for squash")
 }

--- a/summarize.go
+++ b/summarize.go
@@ -50,7 +50,7 @@ func summarize(cfg Config, descriptions DescriptionProvider, s *section, value r
 
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
-		if skipField(f) {
+		if !includeField(f) {
 			continue
 		}
 
@@ -134,7 +134,7 @@ func printVal(cfg Config, value reflect.Value, indent string) string {
 	case isStruct(t):
 		for i := 0; i < t.NumField(); i++ {
 			f := t.Field(i)
-			if skipField(f) {
+			if !includeField(f) {
 				continue
 			}
 


### PR DESCRIPTION
Fixes an issue introduced by #27 where summarizing an application's config could panic if the config contained embedded structs. Adds tests to ensure that field describers don't panic in this situation.

~~Note: On this branch, there's an inconsistency in loading vs summarizing config: configs that contain and embedded pointer to an unexported struct type can be summarized but not loaded. I think this should be updated so that they are neither summarized nor exported, but am looking for some feedback.~~

~~Another approach might be to simply panic if `Load` or `Summarize` is called when the application config contains embedded pointers to unexported struct types, since having an omitted sub-object is likely a bug.~~

Thanks @kzantow for a hand correcting this behavior - the library now ignores fields on config structs if the field is an embedded pointer to a struct of an unexported type.