### PR TITLE
fix: summarize pointers to primitives correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.17.0
 	github.com/stretchr/testify v1.8.4
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -34,5 +35,4 @@ require (
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/adrg/xdg v0.4.0
 	github.com/anchore/go-logger v0.0.0-20230531193951-db5ae83e7dbe
+	github.com/google/go-cmp v0.5.9
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,7 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=

--- a/summarize.go
+++ b/summarize.go
@@ -104,13 +104,11 @@ func summarize(cfg Config, descriptions DescriptionProvider, s *section, value r
 }
 
 // printVal prints a value in YAML format
+// nolint:gocognit
 func printVal(cfg Config, value reflect.Value, indent string) string {
 	buf := bytes.Buffer{}
 
 	v, t := base(value)
-	if v.Kind() == reflect.Ptr && v.IsNil() {
-		return ""
-	}
 	switch {
 	case isSlice(t):
 		if v.Len() == 0 {
@@ -171,12 +169,15 @@ func printVal(cfg Config, value reflect.Value, indent string) string {
 		}
 
 	case v.CanInterface():
-		iFace := v.Interface()
-		switch iFace.(type) {
+		if v.Kind() == reflect.Ptr && v.IsNil() {
+			return ""
+		}
+		v := v.Interface()
+		switch v.(type) {
 		case string:
-			return fmt.Sprintf("'%s'", iFace)
+			return fmt.Sprintf("'%s'", v)
 		default:
-			return fmt.Sprintf("%v", iFace)
+			return fmt.Sprintf("%v", v)
 		}
 	}
 

--- a/summarize.go
+++ b/summarize.go
@@ -108,6 +108,9 @@ func printVal(cfg Config, value reflect.Value, indent string) string {
 	buf := bytes.Buffer{}
 
 	v, t := base(value)
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		return ""
+	}
 	switch {
 	case isSlice(t):
 		if v.Len() == 0 {
@@ -168,9 +171,6 @@ func printVal(cfg Config, value reflect.Value, indent string) string {
 		}
 
 	case v.CanInterface():
-		if v.Kind() == reflect.Ptr && v.IsNil() {
-			return ""
-		}
 		iFace := v.Interface()
 		switch iFace.(type) {
 		case string:

--- a/summarize_test.go
+++ b/summarize_test.go
@@ -3,6 +3,7 @@ package fangs
 import (
 	"fmt"
 	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
 	"strings"
 	"testing"
 
@@ -358,13 +359,13 @@ SubSlice:
 
 func TestSummarizePtr(t *testing.T) {
 	type T1 struct {
-		TopBoolPtrNil   *bool
-		TopBoolPtrTrue  *bool
-		TopBoolPtrFalse *bool
-		TopStringPtrNil *string
-		TopStringPtrSet *string
-		TopIntPtrNil    *int
-		TopIntPtrSet    *int
+		TopBoolPtrNil   *bool   `yaml:"TopBoolPtrNil"`
+		TopBoolPtrTrue  *bool   `yaml:"TopBoolPtrTrue"`
+		TopBoolPtrFalse *bool   `yaml:"TopBoolPtrFalse"`
+		TopStringPtrNil *string `yaml:"TopStringPtrNil"`
+		TopStringPtrSet *string `yaml:"TopStringPtrSet"`
+		TopIntPtrNil    *int    `yaml:"TopIntPtrNil"`
+		TopIntPtrSet    *int    `yaml:"TopIntPtrSet"`
 	}
 
 	cfg := NewConfig("my-app")
@@ -412,6 +413,16 @@ TopIntPtrSet: 42
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unexpected summary (-want +got):\n%s", diff)
+	}
+
+	// ensure that we can yaml.Unmarshal the way we encode nil ptrs
+	var emptyConfig T1
+	err := yaml.Unmarshal([]byte(got), &emptyConfig)
+	require.NoError(t, err)
+	newSummary := SummarizeCommand(cfg, subCmd, emptyConfig)
+
+	if diff := cmp.Diff(got, newSummary); diff != "" {
+		t.Errorf("unexpected diff from serialize round trip (-before +after):\n%s", diff)
 	}
 }
 

--- a/summarize_test.go
+++ b/summarize_test.go
@@ -2,17 +2,17 @@ package fangs
 
 import (
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"gopkg.in/yaml.v3"
 	"strings"
 	"testing"
 
 	"github.com/adrg/xdg"
+	"github.com/google/go-cmp/cmp"
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/anchore/go-logger/adapter/discard"
 )


### PR DESCRIPTION
Previously, commands like `syft help` would have output like this:

```
... snip
  
  format:
    # (env: SYFT_FORMAT_PRETTY)
    pretty: 0x14000738350
    
    template:
      # specify the path to a Go template file (env: SYFT_FORMAT_TEMPLATE_PATH)

... snip
```

Instead, print an empty string when a field that's a pointer to a primitive type has value `nil`, like this:

```
... snip
  format:
    # (env: SYFT_FORMAT_PRETTY)
    pretty:

    template:
      # specify the path to a Go template file (env: SYFT_FORMAT_TEMPLATE_PATH)
... snip
```

Include additional testing for pointers in config structs.
