### PR TITLE
feat: summarize with value filter

### DIFF
--- a/summarize.go
+++ b/summarize.go
@@ -17,6 +17,11 @@ func Summarize(cfg Config, descriptions DescriptionProvider, filter ValueFilterF
 		v := reflect.ValueOf(value)
 		summarize(cfg, descriptions, root, v, nil)
 	}
+	if filter == nil {
+		filter = func(s string) string {
+			return s
+		}
+	}
 	return root.stringify(cfg, filter)
 }
 

--- a/summarize_test.go
+++ b/summarize_test.go
@@ -50,7 +50,7 @@ func Test_Summarize(t *testing.T) {
 	AddFlags(discard.New(), cmd.Flags(), &t0.S1)
 
 	cfg := NewConfig("app")
-	s := SummarizeCommand(cfg, cmd, filterPass, t0, &t0.S0, &t0.S1)
+	s := SummarizeCommand(cfg, cmd, nil, t0, &t0.S0, &t0.S1)
 	require.Equal(t, `# name0 usage flag (env: APP_NAME0)
 Name0: 'name0 val'
 
@@ -174,7 +174,7 @@ func Test_SummarizeValues(t *testing.T) {
 
 	describers := DescriptionProviders(d1, desc, NewStructDescriptionTagProvider())
 
-	s := Summarize(cfg, describers, filterPass, t1)
+	s := Summarize(cfg, describers, nil, t1)
 
 	require.Equal(t, `# top-bool manual description (env: APP_TOPBOOL)
 TopBool: false
@@ -302,7 +302,7 @@ func Test_SummarizeValuesWithPointers(t *testing.T) {
 	cmd.Flags().StringVar(&t1.TopString, "top-string", "", "top-string command description")
 	AddFlags(cfg.Logger, subCmd.Flags(), t1)
 
-	got := SummarizeCommand(cfg, subCmd, filterPass, t1)
+	got := SummarizeCommand(cfg, subCmd, nil, t1)
 
 	want := `# (env: MY_APP_TOPBOOL)
 TopBool: false
@@ -386,7 +386,7 @@ func TestSummarizePtr(t *testing.T) {
 
 	AddFlags(cfg.Logger, subCmd.Flags(), t1)
 
-	got := SummarizeCommand(cfg, subCmd, filterPass, t1)
+	got := SummarizeCommand(cfg, subCmd, nil, t1)
 
 	want := `# (env: MY_APP_TOPBOOLPTRNIL)
 TopBoolPtrNil:
@@ -419,7 +419,7 @@ TopIntPtrSet: 42
 	var emptyConfig T1
 	err := yaml.Unmarshal([]byte(got), &emptyConfig)
 	require.NoError(t, err)
-	newSummary := SummarizeCommand(cfg, subCmd, filterPass, emptyConfig)
+	newSummary := SummarizeCommand(cfg, subCmd, nil, emptyConfig)
 
 	if diff := cmp.Diff(got, newSummary); diff != "" {
 		t.Errorf("unexpected diff from serialize round trip (-before +after):\n%s", diff)
@@ -439,7 +439,7 @@ func Test_SummarizeWithEmbeddedPublicStruct(t *testing.T) {
 
 	AddFlags(discard.New(), root.Flags(), appConfigPtr)
 	cfg := NewConfig("app")
-	s := SummarizeCommand(cfg, root, filterPass, appConfigPtr)
+	s := SummarizeCommand(cfg, root, nil, appConfigPtr)
 	expected := `# (env: APP_VALUE)
 value: false
 
@@ -467,7 +467,7 @@ func Test_SummarizeWithEmbeddedPublicStructPointer(t *testing.T) {
 
 	AddFlags(discard.New(), root.Flags(), appConfigPtr)
 	cfg := NewConfig("app")
-	s := SummarizeCommand(cfg, root, filterPass, appConfigPtr)
+	s := SummarizeCommand(cfg, root, nil, appConfigPtr)
 	expected := `# (env: APP_VALUE)
 value: false
 
@@ -495,7 +495,7 @@ func Test_SummarizeWithEmbeddedPrivateStruct(t *testing.T) {
 
 	AddFlags(discard.New(), root.Flags(), appConfigPtr)
 	cfg := NewConfig("app")
-	s := SummarizeCommand(cfg, root, filterPass, appConfigPtr)
+	s := SummarizeCommand(cfg, root, nil, appConfigPtr)
 	expected := `# (env: APP_VALUE)
 value: false
 
@@ -525,7 +525,7 @@ func Test_SummarizeWithEmbeddedPrivateStructPointer(t *testing.T) {
 
 	AddFlags(discard.New(), root.Flags(), appConfigPtr)
 	cfg := NewConfig("app")
-	s := SummarizeCommand(cfg, root, filterPass, appConfigPtr)
+	s := SummarizeCommand(cfg, root, nil, appConfigPtr)
 	expected := `# (env: APP_SOMETHING)
 something: false
 
@@ -597,8 +597,4 @@ func Test_SummarizeLocations(t *testing.T) {
 	expected := fmt.Sprintf(strings.Repeat("%s\n", len(opts)), opts...)
 
 	require.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(got))
-}
-
-func filterPass(s string) string {
-	return s
 }

--- a/summarize_test.go
+++ b/summarize_test.go
@@ -50,7 +50,7 @@ func Test_Summarize(t *testing.T) {
 	AddFlags(discard.New(), cmd.Flags(), &t0.S1)
 
 	cfg := NewConfig("app")
-	s := SummarizeCommand(cfg, cmd, redactNone, t0, &t0.S0, &t0.S1)
+	s := SummarizeCommand(cfg, cmd, filterPass, t0, &t0.S0, &t0.S1)
 	require.Equal(t, `# name0 usage flag (env: APP_NAME0)
 Name0: 'name0 val'
 
@@ -174,7 +174,7 @@ func Test_SummarizeValues(t *testing.T) {
 
 	describers := DescriptionProviders(d1, desc, NewStructDescriptionTagProvider())
 
-	s := Summarize(cfg, describers, redactNone, t1)
+	s := Summarize(cfg, describers, filterPass, t1)
 
 	require.Equal(t, `# top-bool manual description (env: APP_TOPBOOL)
 TopBool: false
@@ -302,7 +302,7 @@ func Test_SummarizeValuesWithPointers(t *testing.T) {
 	cmd.Flags().StringVar(&t1.TopString, "top-string", "", "top-string command description")
 	AddFlags(cfg.Logger, subCmd.Flags(), t1)
 
-	got := SummarizeCommand(cfg, subCmd, redactNone, t1)
+	got := SummarizeCommand(cfg, subCmd, filterPass, t1)
 
 	want := `# (env: MY_APP_TOPBOOL)
 TopBool: false
@@ -386,7 +386,7 @@ func TestSummarizePtr(t *testing.T) {
 
 	AddFlags(cfg.Logger, subCmd.Flags(), t1)
 
-	got := SummarizeCommand(cfg, subCmd, redactNone, t1)
+	got := SummarizeCommand(cfg, subCmd, filterPass, t1)
 
 	want := `# (env: MY_APP_TOPBOOLPTRNIL)
 TopBoolPtrNil:
@@ -419,7 +419,7 @@ TopIntPtrSet: 42
 	var emptyConfig T1
 	err := yaml.Unmarshal([]byte(got), &emptyConfig)
 	require.NoError(t, err)
-	newSummary := SummarizeCommand(cfg, subCmd, redactNone, emptyConfig)
+	newSummary := SummarizeCommand(cfg, subCmd, filterPass, emptyConfig)
 
 	if diff := cmp.Diff(got, newSummary); diff != "" {
 		t.Errorf("unexpected diff from serialize round trip (-before +after):\n%s", diff)
@@ -439,7 +439,7 @@ func Test_SummarizeWithEmbeddedPublicStruct(t *testing.T) {
 
 	AddFlags(discard.New(), root.Flags(), appConfigPtr)
 	cfg := NewConfig("app")
-	s := SummarizeCommand(cfg, root, redactNone, appConfigPtr)
+	s := SummarizeCommand(cfg, root, filterPass, appConfigPtr)
 	expected := `# (env: APP_VALUE)
 value: false
 
@@ -467,7 +467,7 @@ func Test_SummarizeWithEmbeddedPublicStructPointer(t *testing.T) {
 
 	AddFlags(discard.New(), root.Flags(), appConfigPtr)
 	cfg := NewConfig("app")
-	s := SummarizeCommand(cfg, root, redactNone, appConfigPtr)
+	s := SummarizeCommand(cfg, root, filterPass, appConfigPtr)
 	expected := `# (env: APP_VALUE)
 value: false
 
@@ -495,7 +495,7 @@ func Test_SummarizeWithEmbeddedPrivateStruct(t *testing.T) {
 
 	AddFlags(discard.New(), root.Flags(), appConfigPtr)
 	cfg := NewConfig("app")
-	s := SummarizeCommand(cfg, root, redactNone, appConfigPtr)
+	s := SummarizeCommand(cfg, root, filterPass, appConfigPtr)
 	expected := `# (env: APP_VALUE)
 value: false
 
@@ -525,7 +525,7 @@ func Test_SummarizeWithEmbeddedPrivateStructPointer(t *testing.T) {
 
 	AddFlags(discard.New(), root.Flags(), appConfigPtr)
 	cfg := NewConfig("app")
-	s := SummarizeCommand(cfg, root, redactNone, appConfigPtr)
+	s := SummarizeCommand(cfg, root, filterPass, appConfigPtr)
 	expected := `# (env: APP_SOMETHING)
 something: false
 
@@ -537,21 +537,21 @@ field:
 	assert.Equal(t, expected, s)
 }
 
-func Test_SummarizeRedacting(t *testing.T) {
-	type RedactMe struct {
-		RedactMe string `description:"field named RedactMe"`
+func Test_SummarizeFiltering(t *testing.T) {
+	type FilterMe struct {
+		FilterMe string `description:"field named FilterMe"`
 	}
 
 	root := &cobra.Command{}
 	cfg := NewConfig("app")
-	val := RedactMe{
-		RedactMe: "RedactMe",
+	val := FilterMe{
+		FilterMe: "FilterMe",
 	}
-	redactor := func(_ string) string {
-		return "REDACTED"
+	filter := func(_ string) string {
+		return "FILTERED"
 	}
-	summary := SummarizeCommand(cfg, root, redactor, val)
-	require.Equal(t, "# field named RedactMe (env: APP_REDACTME)\nRedactMe: 'REDACTED'\n\n", summary)
+	summary := SummarizeCommand(cfg, root, filter, val)
+	require.Equal(t, "# field named FilterMe (env: APP_FILTERME)\nFilterMe: 'FILTERED'\n\n", summary)
 }
 
 func Test_SummarizeLocations(t *testing.T) {
@@ -599,6 +599,6 @@ func Test_SummarizeLocations(t *testing.T) {
 	require.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(got))
 }
 
-func redactNone(s string) string {
+func filterPass(s string) string {
 	return s
 }


### PR DESCRIPTION
This PR adjust the summarization to accept a function to filter each value being output. For example, we could pass a redacting function in order to allows redaction of user values separate from configuration names. For example, if there is a struct with a `password` field and the user has the value `password` redacted, we don't want to redact the _field name_, only the value.