### PR TITLE
Add config profile support

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,11 +9,13 @@ import (
 )
 
 type Config struct {
-	Logger  logger.Logger `yaml:"-" json:"-" mapstructure:"-"`
-	AppName string        `yaml:"-" json:"-" mapstructure:"-"`
-	TagName string        `yaml:"-" json:"-" mapstructure:"-"`
-	File    string        `yaml:"-" json:"-" mapstructure:"-"`
-	Finders []Finder      `yaml:"-" json:"-" mapstructure:"-"`
+	Logger         logger.Logger `yaml:"-" json:"-" mapstructure:"-"`
+	AppName        string        `yaml:"-" json:"-" mapstructure:"-"`
+	TagName        string        `yaml:"-" json:"-" mapstructure:"-"`
+	File           string        `yaml:"-" json:"-" mapstructure:"-"`
+	Finders        []Finder      `yaml:"-" json:"-" mapstructure:"-"`
+	profileEnabled bool
+	Profile        string `yaml:"-" json:"-" mapstructure:"-"`
 }
 
 var _ FlagAdder = (*Config)(nil)
@@ -47,6 +49,18 @@ func (c Config) WithConfigEnvVar() Config {
 	return c
 }
 
+// WithProfileEnvVar looks for the environment variable: <APP_NAME>_PROFILE as a way to specify a profile name
+// This will be overridden by a command-line flag
+func (c Config) WithProfileEnvVar() Config {
+	c.Profile = os.Getenv(envVar(c.AppName, "PROFILE"))
+	c.profileEnabled = true
+	return c
+}
+
 func (c *Config) AddFlags(flags FlagSet) {
 	flags.StringVarP(&c.File, "config", "c", fmt.Sprintf("%s configuration file", c.AppName))
+
+	if c.profileEnabled {
+		flags.StringVarP(&c.Profile, "profile", "", fmt.Sprintf("%s profile configuration file", c.AppName))
+	}
 }

--- a/load.go
+++ b/load.go
@@ -181,7 +181,11 @@ func configureViper(cfg Config, vpr *viper.Viper, v reflect.Value, flags flagRef
 
 func readConfigFile(cfg Config, v *viper.Viper) error {
 	for _, finder := range cfg.Finders {
-		for _, file := range finder(cfg) {
+		locations, err := finder(cfg)
+		if err != nil {
+			return err
+		}
+		for _, file := range locations {
 			if !fileExists(file) {
 				continue
 			}

--- a/summarize.go
+++ b/summarize.go
@@ -40,7 +40,12 @@ func SummarizeCommand(cfg Config, cmd *cobra.Command, filter ValueFilterFunc, va
 
 func SummarizeLocations(cfg Config) (out []string) {
 	for _, f := range cfg.Finders {
-		out = append(out, f(cfg)...)
+		locations, err := f(cfg)
+		if err != nil {
+			// TODO: log?
+			continue
+		}
+		out = append(out, locations...)
 	}
 	return
 }


### PR DESCRIPTION
This adds the (optional) feature to be able to select different configuration profiles based off of a name (not a path). For instance:
```
myapp --profile x
```

would look for `.myapp/x.yaml` to load the app configuration from. 

This also makes a breaking change where finders can return errors. This is also vital for ensuring that when `-c FILE` is specified that we will not use the default configuration (which seems to be a bug today).

This is a proof of concept and is not meant to be merged as is.