### PR TITLE
fix: more expected help output for bool ptr

### DIFF
--- a/var.go
+++ b/var.go
@@ -39,7 +39,7 @@ func (b *boolPtr) Set(s string) error {
 }
 
 func (b *boolPtr) Type() string {
-	return "*bool"
+	return "bool"
 }
 
 var _ pflag.Value = (*boolPtr)(nil)


### PR DESCRIPTION
This PR adjusts the BoolPtrVarP to piggyback off the behavior of `bool` types, which adjusts some of the help display. Previously:
```
      --use-network *bool[=true]                  use the network to fetch and augment package information
 ```
with this PR:
```
      --use-network                               use the network to fetch and augment package information
 ```