### PR TITLE
feat: update summarize; removes white space from generated config

### DIFF
--- a/summarize.go
+++ b/summarize.go
@@ -268,7 +268,7 @@ func (s *section) add(log logger.Logger, name string, value reflect.Value, descr
 func (s *section) stringify(cfg Config, filter ValueFilterFunc) string {
 	out := &bytes.Buffer{}
 	stringifySection(cfg, filter, out, s, "")
-	return out.String()
+	return cleanContent(out)
 }
 
 func stringifySection(cfg Config, filter ValueFilterFunc, out *bytes.Buffer, s *section, indent string) {
@@ -325,4 +325,46 @@ func stringifySection(cfg Config, filter ValueFilterFunc, out *bytes.Buffer, s *
 			out.WriteString("\n")
 		}
 	}
+}
+
+func cleanContent(buffer *bytes.Buffer) string {
+	// Convert buffer to string
+	content := string(buffer.String())
+
+	// Split the content into lines
+	lines := strings.Split(content, "\n")
+
+	// Process each line to trim leading and trailing whitespace
+	var processedLines []string
+	for _, line := range lines {
+		// Trim leading and trailing whitespace
+		trimmedLine := strings.TrimSpace(line)
+
+		// Preserve indentation by re-calculating indentation and re-adding it
+		if len(trimmedLine) > 0 {
+			// Calculate the leading spaces (indentation)
+			indentation := ""
+			for _, char := range line {
+				if char == ' ' {
+					indentation += " "
+				} else {
+					break
+				}
+			}
+
+			// Rebuild the line with preserved indentation but no trailing spaces
+			processedLines = append(processedLines, indentation+trimmedLine)
+		} else {
+			// Keep empty lines intact
+			processedLines = append(processedLines, "")
+		}
+	}
+
+	// Join the lines back into a single string
+	cleanContent := strings.Join(processedLines, "\n")
+
+	// Convert the cleaned content back to a buffer
+	cleanBuffer := bytes.NewBufferString(cleanContent)
+
+	return cleanBuffer.String()
 }

--- a/summarize.go
+++ b/summarize.go
@@ -329,7 +329,7 @@ func stringifySection(cfg Config, filter ValueFilterFunc, out *bytes.Buffer, s *
 
 func cleanContent(buffer *bytes.Buffer) string {
 	// Convert buffer to string
-	content := string(buffer.String())
+	content := buffer.String()
 
 	// Split the content into lines
 	lines := strings.Split(content, "\n")

--- a/summarize.go
+++ b/summarize.go
@@ -336,26 +336,7 @@ func cleanWhiteSpace(buffer *bytes.Buffer) string {
 	var processedLines []string
 	for _, line := range lines {
 		// Trim leading and trailing whitespace
-		trimmedLine := strings.TrimSpace(line)
-
-		// Preserve indentation by re-calculating indentation and re-adding it
-		if len(trimmedLine) > 0 {
-			// Calculate the leading spaces (indentation)
-			indentation := ""
-			for _, char := range line {
-				if char == ' ' {
-					indentation += " "
-				} else {
-					break
-				}
-			}
-
-			// Rebuild the line with preserved indentation but no trailing spaces
-			processedLines = append(processedLines, indentation+trimmedLine)
-		} else {
-			// Keep empty lines intact
-			processedLines = append(processedLines, "")
-		}
+		processedLines = append(processedLines, strings.TrimRight(line, " "))
 	}
 
 	return strings.Join(processedLines, "\n")

--- a/summarize.go
+++ b/summarize.go
@@ -268,7 +268,7 @@ func (s *section) add(log logger.Logger, name string, value reflect.Value, descr
 func (s *section) stringify(cfg Config, filter ValueFilterFunc) string {
 	out := &bytes.Buffer{}
 	stringifySection(cfg, filter, out, s, "")
-	return cleanContent(out)
+	return cleanWhiteSpace(out)
 }
 
 func stringifySection(cfg Config, filter ValueFilterFunc, out *bytes.Buffer, s *section, indent string) {
@@ -327,7 +327,7 @@ func stringifySection(cfg Config, filter ValueFilterFunc, out *bytes.Buffer, s *
 	}
 }
 
-func cleanContent(buffer *bytes.Buffer) string {
+func cleanWhiteSpace(buffer *bytes.Buffer) string {
 	content := buffer.String()
 
 	lines := strings.Split(content, "\n")

--- a/summarize.go
+++ b/summarize.go
@@ -328,10 +328,8 @@ func stringifySection(cfg Config, filter ValueFilterFunc, out *bytes.Buffer, s *
 }
 
 func cleanContent(buffer *bytes.Buffer) string {
-	// Convert buffer to string
 	content := buffer.String()
 
-	// Split the content into lines
 	lines := strings.Split(content, "\n")
 
 	// Process each line to trim leading and trailing whitespace
@@ -360,11 +358,5 @@ func cleanContent(buffer *bytes.Buffer) string {
 		}
 	}
 
-	// Join the lines back into a single string
-	cleanContent := strings.Join(processedLines, "\n")
-
-	// Convert the cleaned content back to a buffer
-	cleanBuffer := bytes.NewBufferString(cleanContent)
-
-	return cleanBuffer.String()
+	return strings.Join(processedLines, "\n")
 }

--- a/summarize.go
+++ b/summarize.go
@@ -272,6 +272,8 @@ func (s *section) add(log logger.Logger, name string, value reflect.Value, descr
 func (s *section) stringify(cfg Config, filter ValueFilterFunc) string {
 	out := &bytes.Buffer{}
 	stringifySection(cfg, filter, out, s, "")
+
+	// remove any extra trailing whitespace from final config
 	return trailingSpace.ReplaceAllString(out.String(), "\n")
 }
 

--- a/summarize.go
+++ b/summarize.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/anchore/go-logger"
 )
+
+var trailingSpace = regexp.MustCompile(`[ \r]+\n`)
 
 func Summarize(cfg Config, descriptions DescriptionProvider, filter ValueFilterFunc, values ...any) string {
 	root := &section{}
@@ -22,6 +25,7 @@ func Summarize(cfg Config, descriptions DescriptionProvider, filter ValueFilterF
 			return s
 		}
 	}
+
 	return root.stringify(cfg, filter)
 }
 
@@ -268,7 +272,7 @@ func (s *section) add(log logger.Logger, name string, value reflect.Value, descr
 func (s *section) stringify(cfg Config, filter ValueFilterFunc) string {
 	out := &bytes.Buffer{}
 	stringifySection(cfg, filter, out, s, "")
-	return cleanWhiteSpace(out)
+	return trailingSpace.ReplaceAllString(out.String(), "\n")
 }
 
 func stringifySection(cfg Config, filter ValueFilterFunc, out *bytes.Buffer, s *section, indent string) {
@@ -325,19 +329,4 @@ func stringifySection(cfg Config, filter ValueFilterFunc, out *bytes.Buffer, s *
 			out.WriteString("\n")
 		}
 	}
-}
-
-func cleanWhiteSpace(buffer *bytes.Buffer) string {
-	content := buffer.String()
-
-	lines := strings.Split(content, "\n")
-
-	// Process each line to trim leading and trailing whitespace
-	var processedLines []string
-	for _, line := range lines {
-		// Trim leading and trailing whitespace
-		processedLines = append(processedLines, strings.TrimRight(line, " "))
-	}
-
-	return strings.Join(processedLines, "\n")
 }

--- a/summarize_test.go
+++ b/summarize_test.go
@@ -60,11 +60,11 @@ Type0: 'type0 val'
 s2-0:
   # field 1 usage (env: APP_S2_0_FIELD1)
   Field1: 10
-  
+
   # field2 described
   # multiline (env: APP_S2_0_FIELD2)
   Field2: true
-  
+
 # described name (env: APP_NAME)
 Name: 's1 name'
 
@@ -74,11 +74,11 @@ Type: 's1 type'
 s2:
   # field 1 usage (env: APP_S2_FIELD1)
   Field1: 11
-  
+
   # field2 described
   # multiline (env: APP_S2_FIELD2)
   Field2: false
-  
+
 `, s)
 }
 
@@ -191,32 +191,32 @@ val-tsub1: 0
 TSub2:
   # sub2-name command description (env: APP_TSUB2_NAME_TSUB2)
   name-tsub2: ''
-  
+
   # val2 inline tag description (env: APP_TSUB2_VAL)
   Val: 0
-  
+
 sub3:
   # (env: APP_SUB3_NAME_TSUB3)
   name-tsub3: ''
-  
+
   # sub3-val manual description (env: APP_SUB3_VAL)
   Val: 0
-  
+
 sub4:
   TSub1:
     # (env: APP_SUB4_TSUB1_NAME)
     Name: ''
-    
+
     # val1 inline tag description (env: APP_SUB4_TSUB1_VAL_TSUB1)
     val-tsub1: 0
-    
+
   Sub2:
     # (env: APP_SUB4_SUB2_NAME_TSUB2)
     name-tsub2: ''
-    
+
     # val2 inline tag description (env: APP_SUB4_SUB2_VAL)
     Val: 0
-    
+
 `, s)
 }
 
@@ -325,28 +325,28 @@ summarize1-val: 0
 ptr:
   # summarize2-name command description (env: MY_APP_PTR_SUMMARIZE2_NAME)
   summarize2-name: 'summarize2 name'
-  
+
   # val 2 description (env: MY_APP_PTR_VAL)
   Val: 2
-  
+
 nil:
   # summarize3-name command description (env: MY_APP_NIL_SUMMARIZE3_NAME)
   summarize3-name: ''
-  
+
   # val 2 description (env: MY_APP_NIL_VAL)
   Val: 0
-  
+
 # (env: MY_APP_STRINGSLICE)
-StringSlice: 
+StringSlice:
   - 's1'
   - 's2'
 
-SubSlice: 
+SubSlice:
   - SubValue: 'sv1'
     IntSlice: []
 
   - SubValue: 'sv2'
-    IntSlice: 
+    IntSlice:
       - 3
       - 2
       - 1
@@ -446,10 +446,10 @@ value: false
 field:
   # (env: APP_FIELD_VALUE)
   value: false
-  
+
   # (env: APP_FIELD_SECONDARY)
   secondary: false
-  
+
 `
 	assert.Equal(t, expected, s)
 }
@@ -474,10 +474,10 @@ value: false
 field:
   # (env: APP_FIELD_VALUE)
   value: false
-  
+
   # (env: APP_FIELD_SECONDARY)
   secondary: false
-  
+
 `
 	assert.Equal(t, expected, s)
 }
@@ -502,10 +502,10 @@ value: false
 field:
   # (env: APP_FIELD_VALUE)
   value: false
-  
+
   # (env: APP_FIELD_SECONDARY)
   secondary: false
-  
+
 `
 	assert.Equal(t, expected, s)
 }
@@ -532,7 +532,7 @@ something: false
 field:
   # (env: APP_FIELD_SECONDARY)
   secondary: false
-  
+
 `
 	assert.Equal(t, expected, s)
 }


### PR DESCRIPTION
## Summary

This PR adds a small post processor to the stringify function to remove trailing/leading white space from the generated config.

The left screenshot is the updated config. The right screenshot is what the config looked like before this PR WITH the white space.
<img width="1713" alt="Screenshot 2024-09-12 at 12 42 45 PM" src="https://github.com/user-attachments/assets/21ef6e87-93f6-4dba-9ea3-bc01689a53a5">

### Testing
For testing I updated the current fixtures so they also remove the white space.