### PR TITLE
chore(deps): restore Go version to 1.24.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/anchore/fangs
 
-
-go 1.26.2
+go 1.24.0
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
Restores the go directive in go.mod to 1.24.0 (pre-#125). Bumped in #125 (merge d75d8c680dfe130c9aa0a1538eea5a3c2428068c).